### PR TITLE
Add RunAndReport helper

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package gosh
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 /*
@@ -76,8 +77,13 @@ func whoru(val reflect.Value) string {
 type FailureExitCode struct {
 	Cmdname string
 	Code    int
+	Message string
 }
 
 func (err FailureExitCode) Error() string {
-	return fmt.Sprintf("gosh: command \"%s\" exited with unexpected status %d", err.Cmdname, err.Code)
+	msg := ""
+	if err.Message != "" {
+		msg = "\n\tCommand output was:\n\t\t\"\"\"\n\t\t" + strings.Replace(err.Message, "\n", "\n\t\t", -1) + "\n\t\t\"\"\""
+	}
+	return fmt.Sprintf("gosh: command \"%s\" exited with unexpected status %d%s", err.Cmdname, err.Code, msg)
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -40,6 +40,33 @@ func TestMergineOptss(t *testing.T) {
 	})
 }
 
+func TestInvocationBehaviors(t *testing.T) {
+	// still presumes exec as the backing invoker, regretably
+	Convey("Given a command that will succeed", t, func() {
+		cmd := Opts{
+			Args: []string{"echo", "success"},
+		}
+		Convey("RunAndReport should have no comment", func() {
+			Gosh(cmd).RunAndReport()
+		})
+	})
+	Convey("Given a command that will exit with 12", t, func() {
+		cmd := Opts{
+			Args: []string{"bash", "-c", "echo failuremessage 1>&2; exit 12"},
+		}
+		Convey("RunAndReport should panic; error should include output", func() {
+			defer func() {
+				err := recover()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldHaveSameTypeAs, FailureExitCode{})
+				errExit := err.(FailureExitCode)
+				So(errExit.Message, ShouldEqual, "failuremessage\n")
+			}()
+			Gosh(cmd).RunAndReport()
+		})
+	})
+}
+
 func TestExecIntegration(t *testing.T) {
 	Convey("Given a command template", t, func() {
 		cmd := Opts{


### PR DESCRIPTION
Add helper method that represents one of the most common usage situations in applications: a job that should be quiet in normal operation, and also give useful output logs along with the error on the occasion that it does go wrong (without writing that boilerplate yourself every time).
