### PR TITLE
Errors overhaul

### DIFF
--- a/exec_proc.go
+++ b/exec_proc.go
@@ -135,7 +135,7 @@ func (p *ExecProc) start() error {
 
 	atomic.StoreInt32(&p.state, int32(RUNNING))
 	if err := p.cmd.Start(); err != nil {
-		p.transitionFinal(ProcStartError{cause: err})
+		p.transitionFinal(ProcMonitorError{Cause: err})
 		return p.err
 	}
 

--- a/exec_proc.go
+++ b/exec_proc.go
@@ -135,6 +135,13 @@ func (p *ExecProc) start() error {
 
 	atomic.StoreInt32(&p.state, int32(RUNNING))
 	if err := p.cmd.Start(); err != nil {
+		if err2, ok := err.(*exec.Error); ok && err2.Err == exec.ErrNotFound {
+			p.transitionFinal(NoSuchCommandError{
+				Name:  p.cmd.Args[0],
+				Cause: err,
+			})
+			return p.err
+		}
 		p.transitionFinal(ProcMonitorError{Cause: err})
 		return p.err
 	}

--- a/exec_proc_launcher.go
+++ b/exec_proc_launcher.go
@@ -9,7 +9,7 @@ import (
 
 var ExecLauncher Launcher = func(cmdt Opts) Proc {
 	if cmdt.Args == nil || len(cmdt.Args) < 1 {
-		panic(ProcStartError{cause: NoArgumentsErr})
+		panic(NoArgumentsErr{})
 	}
 	cmd := exec.Command(cmdt.Args[0], cmdt.Args[1:]...)
 

--- a/exec_proc_test.go
+++ b/exec_proc_test.go
@@ -66,7 +66,36 @@ func TestProcExec(t *testing.T) {
 	})
 
 	Convey("Given a command name that cannot be found", t, func() {
-		// TODO
+		// yes, these are different code paths.  yuck.
+		// chalk this up as another thing gosh helps you with normalizing.
+		Convey("Because the name can't be found", func() {
+			cmd := nilifyFDs(exec.Command("surely-not-a-command"))
+
+			Convey("Launch should fail immediately", func() {
+				defer func() {
+					err := recover()
+					So(err, ShouldNotBeNil)
+					So(err, ShouldHaveSameTypeAs, NoSuchCommandError{})
+					err2 := err.(NoSuchCommandError)
+					So(err2.Name, ShouldEqual, "surely-not-a-command")
+				}()
+				ExecProcCmd(cmd)
+			})
+		})
+		SkipConvey("Because part of the path doesn't exist", func() { // TODO
+			cmd := nilifyFDs(exec.Command("/surely/not/a/command"))
+
+			Convey("Launch should fail immediately", func() {
+				defer func() {
+					err := recover()
+					So(err, ShouldNotBeNil)
+					So(err, ShouldHaveSameTypeAs, NoSuchCommandError{})
+					err2 := err.(NoSuchCommandError)
+					So(err2.Name, ShouldEqual, "/surely/not/a/command")
+				}()
+				ExecProcCmd(cmd)
+			})
+		})
 	})
 
 	Convey("Given commands that will exit non-zero", t, func() {

--- a/exec_proc_test.go
+++ b/exec_proc_test.go
@@ -82,7 +82,7 @@ func TestProcExec(t *testing.T) {
 				ExecProcCmd(cmd)
 			})
 		})
-		SkipConvey("Because part of the path doesn't exist", func() { // TODO
+		Convey("Because part of the path doesn't exist", func() {
 			cmd := nilifyFDs(exec.Command("/surely/not/a/command"))
 
 			Convey("Launch should fail immediately", func() {

--- a/shell.go
+++ b/shell.go
@@ -294,7 +294,7 @@ func bake(cmdt Opts, args ...interface{}) Opts {
 		case []string:
 			cmdt = cmdt.Merge(Opts{Args: arg})
 		default:
-			panic(IncomprehensibleCommandModifier{wat: &arg})
+			panic(IncomprehensibleCommandModifierError{wat: &arg})
 		}
 	}
 	return cmdt


### PR DESCRIPTION
Start an error overhaul: consistency pass.

- Everything is now documented,
- everything fits into one marker interface,
- everything consistently allows field access instead of having silly accessor methods,
- and everything is a typed error (no more value errors; even when they're possible, the inconsistency isn't worth it).

Detection of command-not-found is explicit and stands significantly improved; three different edge cases which os/exec reports separately are all now roped into a single explicit `NoSuchCommandError`.
