### PR TITLE
Add support for sending 'kill' and other signals.

### DIFF
--- a/exec_proc.go
+++ b/exec_proc.go
@@ -122,6 +122,20 @@ func (p *ExecProc) AddExitListener(callback func(Proc)) {
 	}
 }
 
+func (p *ExecProc) Kill() {
+	err := p.cmd.Process.Kill()
+	if err != nil {
+		panic(ProcMonitorError{err})
+	}
+}
+
+func (p *ExecProc) Signal(sig os.Signal) {
+	err := p.cmd.Process.Signal(sig)
+	if err != nil {
+		panic(ProcMonitorError{err})
+	}
+}
+
 //
 // Below lieth Guts
 //

--- a/exec_proc_test.go
+++ b/exec_proc_test.go
@@ -188,6 +188,21 @@ func TestProcExec(t *testing.T) {
 		})
 	})
 
+	Convey("Given commands that nobody likes", t, func() {
+		cmd := nilifyFDs(exec.Command("sleep", "2"))
+		tStart := time.Now()
+		p := ExecProcCmd(cmd)
+		Convey("Kill should cause near immediate return", FailureContinues, func() {
+			p.Kill()
+			code := p.GetExitCode()
+			So(time.Now(), ShouldHappenWithin, time.Duration(200*time.Millisecond), tStart)
+			Convey("Proc should be finished with code", FailureContinues, func() {
+				So(code, ShouldEqual, 128+9)
+				So(p.State(), ShouldEqual, FINISHED)
+			})
+		})
+	})
+
 	Convey("Given commands that will recieve signals", t, func() {
 		// TODO
 	})

--- a/proc.go
+++ b/proc.go
@@ -1,6 +1,7 @@
 package gosh
 
 import (
+	"os"
 	"time"
 )
 
@@ -82,6 +83,10 @@ type Proc interface {
 		will be invoked immediately in the current goroutine.
 	*/
 	AddExitListener(callback func(Proc))
+
+	Kill()
+
+	Signal(os.Signal)
 }
 
 // TODO: The template system should know how to accept exit listeners up front.


### PR DESCRIPTION
Add support for sending 'kill' and other signals.

This is basically a proxy to the methods on `os.Process` for the exec implementation of `Proc`.